### PR TITLE
Unwrapping an optional

### DIFF
--- a/Rower/Concept2-SDK/Delegates/PeripheralDelegate.swift
+++ b/Rower/Concept2-SDK/Delegates/PeripheralDelegate.swift
@@ -49,11 +49,13 @@ final class PeripheralDelegate: NSObject, CBPeripheralDelegate {
     
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         print("[PerformanceMonitor]didUpdateValueForCharacteristic: \(characteristic)")
-        if let svc = Service(uuid: characteristic.service.uuid) {
-            if let c = svc.characteristic(uuid: characteristic.uuid) {
-                let cm = c.parse(data: characteristic.value as NSData?)
-                if let pm = performanceMonitor {
-                    cm?.updatePerformanceMonitor(performanceMonitor: pm)
+        if let optionalService = characteristic.service {
+            if let svc = Service(uuid: optionalService.uuid) {
+                if let c = svc.characteristic(uuid: characteristic.uuid) {
+                    let cm = c.parse(data: characteristic.value as NSData?)
+                    if let pm = performanceMonitor {
+                        cm?.updatePerformanceMonitor(performanceMonitor: pm)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Without unwrapping the optional service we get a build error.

```
concept2_rower/Rower/Concept2-SDK/Delegates/PeripheralDelegate.swift:53:55: Value of optional type 'CBService?' must be unwrapped to refer to member 'uuid' of wrapped base type 'CBService'
```